### PR TITLE
bugfix: use is rather than == for exclusion test

### DIFF
--- a/ipython_nose.py
+++ b/ipython_nose.py
@@ -250,7 +250,7 @@ class ExcludingTestSelector(defaultSelector):
     def _in_excluded_objects(self, obj):
         for excluded_object in self.excluded_objects:
             try:
-                if obj == excluded_object:
+                if obj is excluded_object:
                     return True
             except Exception:
                 return False


### PR DESCRIPTION
@rv2e, this is a small change, but is important for performance. I'm going to merge, so I can put it up with the shell changes.

addresses #3